### PR TITLE
Created coprime.cpp

### DIFF
--- a/coprime.cpp
+++ b/coprime.cpp
@@ -1,0 +1,58 @@
+#include <cstdio>
+#include <set>
+#include <NTL/lzz_p.h>
+#include <NTL/tools.h>
+using namespace std;
+using namespace NTL;
+
+const int n = 1e7, k = 1e7, N = n + 10, M = 1048576, MOD = 1000000007;
+
+long f[N];
+zz_p g[M], tmp[M];
+
+void fwt(zz_p *g, int width, int n) {
+    if (n == 1)
+        return;
+    fwt(g        , 2 * width, n/2);
+    fwt(g + width, 2 * width, n/2);
+
+    for (int i = 0; i < n/2; ++i) {
+        zz_p u = g[i * width * 2], v = g[i * width * 2 + width];
+        tmp[i        ] = u + v;
+        tmp[i + n/2] = u - v;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        g[width * i] = tmp[i];
+    }
+}
+
+int main() {
+    zz_p::init(MOD);
+
+    for (int i = 1; i <= n; ++i)
+        f[i] = -1;
+    f[1] = 1;
+
+    int cnt = 0;
+    for (int i = 2; i <= n; ++i)
+        if (f[i] == -1) {
+            ++cnt;
+            f[i] = cnt == 1 ? 0 : cnt;
+            for (int j = i; j <= n; j += i)
+                if (f[j] == -1)
+                    f[j] = f[i];
+        }
+    for (int i = 1; i < n; ++i)
+        ++g[f[i]];
+
+    printf("%d\n", cnt);
+    fwt(g, 1, M);
+    zz_p coef = 1/zz_p(M);
+    for (int i = 0; i < M; ++i)
+        g[i] = power(g[i], k) * coef;
+    fwt(g, 1, M);
+    printf("ans = %ld\n", rep(g[0]));
+
+    return 0;
+}


### PR DESCRIPTION
Solution of Q no. 560 "Coprime Nim is just like ordinary normal play Nim, but the players may only remove a number of stones from a pile that is coprime with the current size of the pile. Two players remove stones in turn. The player who removes the last stone wins.

Let L(n, k) be the number of losing starting positions for the first player, assuming perfect play, when the game is played with k piles, each having between 1 and n - 1 stones inclusively.

For example, L(5, 2) = 6 since the losing initial positions are (1, 1), (2, 2), (2, 4), (3, 3), (4, 2) and (4, 4).
You are also given L(10, 5) = 9964, L(10, 10) = 472400303, L(103, 103) mod 1 000 000 007 = 954021836.

Find L(107, 107) mod 1 000 000 007

"